### PR TITLE
Keep particle count consistent and bounded, seed random pts in resampling step

### DIFF
--- a/echoflow/include/echoflow/particle_filter.hpp
+++ b/echoflow/include/echoflow/particle_filter.hpp
@@ -102,6 +102,7 @@ public:
 
   double observation_sigma_;  // Standard deviation for Gaussian weight function
   double decay_factor_;       // Decay factor for particle weight
+  double seed_fraction_;      // Fraction of particles to be seeded with random positions
   double min_resample_speed_; // Minimum speed for resampling particles
   double noise_std_pos_;      // Standard deviation for position noise
   double noise_std_yaw_;      // Standard deviation for yaw noise

--- a/echoflow/include/echoflow/particle_filter.hpp
+++ b/echoflow/include/echoflow/particle_filter.hpp
@@ -85,11 +85,19 @@ public:
    */
   void resample(std::shared_ptr<grid_map::GridMap> map_ptr);
 
-
+  /**
+   * @brief Get valid positions from the grid map.
+   *
+   * Returns a vector of positions where the grid map has valid data (i.e., where radar intensity > 0).
+   * This is used for seeding new particles.
+   *
+   * @param map_ptr Shared pointer to GridMap with radar intensity-based targets to track.
+   * @return std::vector<grid_map::Position> Vector of valid positions.
+   */
   std::vector<grid_map::Position> getValidPositionsFromMap(const std::shared_ptr<grid_map::GridMap>& map_ptr);
 
   /**
-   * @brief updateNoiseDistributions
+   * @brief Update the noise distributions for particle motion used in the predict step.
    */
   void updateNoiseDistributions();
 

--- a/echoflow/include/echoflow/particle_filter.hpp
+++ b/echoflow/include/echoflow/particle_filter.hpp
@@ -85,6 +85,9 @@ public:
    */
   void resample(std::shared_ptr<grid_map::GridMap> map_ptr);
 
+
+  std::vector<grid_map::Position> getValidPositionsFromMap(const std::shared_ptr<grid_map::GridMap>& map_ptr);
+
   /**
    * @brief updateNoiseDistributions
    */

--- a/echoflow/include/echoflow/particle_filter.hpp
+++ b/echoflow/include/echoflow/particle_filter.hpp
@@ -83,7 +83,7 @@ public:
    * distribution around each particle.
    *
    */
-  void resample();
+  void resample(std::shared_ptr<grid_map::GridMap> map_ptr);
 
   /**
    * @brief updateNoiseDistributions

--- a/echoflow/include/echoflow/particle_filter_node.hpp
+++ b/echoflow/include/echoflow/particle_filter_node.hpp
@@ -45,8 +45,9 @@ public:
       int num_particles = 100000;
       double update_interval = 0.1;            // seconds
       double initial_max_speed = 20.0;
-      double observation_sigma = 100.0;
-      double decay_factor = 0.95;
+      double observation_sigma = 25.0;
+      double decay_factor = 0.5;               // decay factor for particle weights;
+      double seed_fraction = 0.001;            // fraction of particles to be seeded with random positions
       double min_resample_speed = 3.0;
       double noise_std_pos = 0.1;
       double noise_std_yaw = 0.4;

--- a/echoflow/src/particle_filter.cpp
+++ b/echoflow/src/particle_filter.cpp
@@ -31,16 +31,18 @@ void MultiTargetParticleFilter::initialize(std::shared_ptr<grid_map::GridMap> ma
     return;
   }
 
+  std::uniform_real_distribution<double> uniform_01(0.0, 1.0);
+
   // Add new particles at randomly selected valid positions
   // TODO: revisit this section for tracking different sizes of blobs or "ignoring" static blobs
   for (size_t i = 0; i < num_particles_; ++i) {
-    const auto& position = valid_positions[rand() % valid_positions.size()];
+      const auto& position = valid_positions[rng_() % valid_positions.size()];
     Target particle;
     particle.x = position.x();
     particle.y = position.y();
-    particle.speed = initial_max_speed_ * static_cast<double>(rand()) / RAND_MAX;
-    particle.heading = 2.0 * M_PI * static_cast<double>(rand()) / RAND_MAX;
-    particle.yaw_rate = 0.0 * static_cast<double>(rand()) / RAND_MAX; // This is ZERO always...
+    particle.speed = initial_max_speed_ * uniform_01(rng_);
+    particle.heading = 2.0 * M_PI * uniform_01(rng_);
+    particle.yaw_rate = 0.0 * uniform_01(rng_); // THIS IS ALWAYS ZERO
     particle.weight = 1.0;  // Will be normalized later
     particles_.push_back(particle);
   }
@@ -117,7 +119,7 @@ void MultiTargetParticleFilter::updateWeights(std::shared_ptr<grid_map::GridMap>
 void MultiTargetParticleFilter::resample(std::shared_ptr<grid_map::GridMap> map_ptr)
 {
     const size_t n_total = num_particles_;
-    const size_t n_seed = static_cast<size_t>(0.001 * n_total); // 0.1% of total particles are seeded
+    const size_t n_seed = static_cast<size_t>(seed_fraction_ * n_total); // 0.1% of total particles are seeded
     const size_t n_resample = n_total - n_seed;
 
     std::vector<Target> new_particles;
@@ -146,10 +148,10 @@ void MultiTargetParticleFilter::resample(std::shared_ptr<grid_map::GridMap> map_
     std::uniform_real_distribution<double> uniform_01(0.0, 1.0);
 
     for (size_t m = 0; m < n_seed && !valid_positions.empty(); ++m) {
-        const auto& pos = valid_positions[rng_() % valid_positions.size()];
+        const auto& position = valid_positions[rng_() % valid_positions.size()];
         Target particle;
-        particle.x = pos.x();
-        particle.y = pos.y();
+        particle.x = position.x();
+        particle.y = position.y();
         particle.speed = initial_max_speed_ * uniform_01(rng_);
         particle.heading = 2.0 * M_PI * uniform_01(rng_);
         particle.yaw_rate = 0.0;

--- a/echoflow/src/particle_filter.cpp
+++ b/echoflow/src/particle_filter.cpp
@@ -13,9 +13,9 @@ MultiTargetParticleFilter::MultiTargetParticleFilter(size_t num_particles,
 void MultiTargetParticleFilter::initialize(std::shared_ptr<grid_map::GridMap> map_ptr)
 {
   RCLCPP_DEBUG(rclcpp::get_logger("MultiTargetParticleFilter"),
-                "ParticleFilter Config: num_particles=%zu, observation_sigma=%.2f, decay=%.2f, "
+                "ParticleFilter Config: num_particles=%zu, observation_sigma=%.2f, decay=%.2f, seed_fraction=%.2f, "
                 "min_speed=%.2f, noise_std_pos=%.2f, noise_std_yaw=%.2f, noise_std_yaw_rate=%.2f, noise_std_speed=%.2f",
-                num_particles_, observation_sigma_, decay_factor_,
+                num_particles_, observation_sigma_, decay_factor_, seed_fraction_,
                 min_resample_speed_, noise_std_pos_, noise_std_yaw_, noise_std_yaw_rate_, noise_std_speed_);
 
   if (!map_ptr || !map_ptr->exists("intensity")) {

--- a/echoflow/src/particle_filter_node.cpp
+++ b/echoflow/src/particle_filter_node.cpp
@@ -70,7 +70,6 @@ ParticleFilterNode::ParticleFilterNode()
               RCLCPP_INFO(this->get_logger(), "Parameter '%s' changed to '%s'",
                           parameter.get_name().c_str(),
                           parameter.value_to_string().c_str());
-              // TODO: (bonney) handle param updates case by case
           }
 
           // parameters that require restart
@@ -152,12 +151,9 @@ void ParticleFilterNode::update()
     initialized_ = true;
   }
 
-  if (!initialized_) return;
-
-  pf_->initialize(map_ptr_);
   pf_->predict(dt);
   pf_->updateWeights(map_ptr_);
-  pf_->resample();
+  pf_->resample(map_ptr_);
   pending_detections_.clear();
 
   publishPointCloud();

--- a/echoflow/src/particle_filter_node.cpp
+++ b/echoflow/src/particle_filter_node.cpp
@@ -10,6 +10,7 @@ void ParticleFilterNode::Parameters::declare(rclcpp::Node * node)
   node->declare_parameter("particle_filter.initial_max_speed", particle_filter.initial_max_speed);
   node->declare_parameter("particle_filter.observation_sigma", particle_filter.observation_sigma);
   node->declare_parameter("particle_filter.decay_factor", particle_filter.decay_factor);
+  node->declare_parameter("particle_filter.seed_fraction", particle_filter.seed_fraction);
   node->declare_parameter("particle_filter.min_resample_speed", particle_filter.min_resample_speed);
   node->declare_parameter("particle_filter.noise_std_pos", particle_filter.noise_std_pos);
   node->declare_parameter("particle_filter.noise_std_yaw", particle_filter.noise_std_yaw);
@@ -31,6 +32,7 @@ void ParticleFilterNode::Parameters::update(rclcpp::Node * node)
   node->get_parameter("particle_filter.initial_max_speed", particle_filter.initial_max_speed);
   node->get_parameter("particle_filter.observation_sigma", particle_filter.observation_sigma);
   node->get_parameter("particle_filter.decay_factor", particle_filter.decay_factor);
+  node->get_parameter("particle_filter.seed_fraction", particle_filter.seed_fraction);
   node->get_parameter("particle_filter.min_resample_speed", particle_filter.min_resample_speed);
   node->get_parameter("particle_filter.noise_std_pos", particle_filter.noise_std_pos);
   node->get_parameter("particle_filter.noise_std_yaw", particle_filter.noise_std_yaw);
@@ -130,6 +132,7 @@ ParticleFilterNode::ParticleFilterNode()
 void ParticleFilterNode::applyParameters() {
     pf_->observation_sigma_ = parameters_.particle_filter.observation_sigma;
     pf_->decay_factor_ = parameters_.particle_filter.decay_factor;
+    pf_->seed_fraction_ = parameters_.particle_filter.seed_fraction;
     pf_->min_resample_speed_ = parameters_.particle_filter.min_resample_speed;
     pf_->noise_std_pos_ = parameters_.particle_filter.noise_std_pos;
     pf_->noise_std_yaw_ = parameters_.particle_filter.noise_std_yaw;


### PR DESCRIPTION
### Summary:

Particles were seeded randomly during the initialize step on every iteration and grew unbounded. The changes keep the particle count consistent throughout by initializing one time with number_particles_ and seeding randomness on the gridmap after the resampling step. 


### Enhancements to particle initialization and resampling:

* [`echoflow/include/echoflow/particle_filter.hpp`](diffhunk://#diff-0163e0efcffd9ffdaafc493ef4cd2a367eab924adb29aaa26c897a95ebde5e53L86-R100): Added the `getValidPositionsFromMap` method to retrieve valid positions from the grid map based on radar intensity. Updated the `resample` method to accept a `map_ptr` parameter and incorporate seeded particles using the new `seed_fraction` parameter. [[1]](diffhunk://#diff-0163e0efcffd9ffdaafc493ef4cd2a367eab924adb29aaa26c897a95ebde5e53L86-R100) [[2]](diffhunk://#diff-0163e0efcffd9ffdaafc493ef4cd2a367eab924adb29aaa26c897a95ebde5e53R113)
* [`echoflow/src/particle_filter.cpp`](diffhunk://#diff-0dfcf5bd278567767c54daba524dab8d811b3d7edea33e5f9b625eb9c5527bd9L9-R18): Refactored the `initialize` and `resample` methods to use `getValidPositionsFromMap` for particle seeding and introduced seeded particles based on the `seed_fraction` parameter. Improved randomization using `std::uniform_real_distribution` instead of `rand()`. [[1]](diffhunk://#diff-0dfcf5bd278567767c54daba524dab8d811b3d7edea33e5f9b625eb9c5527bd9L9-R18) [[2]](diffhunk://#diff-0dfcf5bd278567767c54daba524dab8d811b3d7edea33e5f9b625eb9c5527bd9L28-R51) [[3]](diffhunk://#diff-0dfcf5bd278567767c54daba524dab8d811b3d7edea33e5f9b625eb9c5527bd9L130-R189)

### Parameter management improvements:

* [`echoflow/src/particle_filter_node.cpp`](diffhunk://#diff-f8ee6b133be44bdc6cb0d7b6ff9cfa886807ec0a8bdb838b09775d00c612a482R13): Added `seed_fraction` as a configurable parameter in the `declare`, `update`, and `applyParameters` methods. Updated the resampling logic in the `update` method to pass the grid map pointer to the `resample` function. [[1]](diffhunk://#diff-f8ee6b133be44bdc6cb0d7b6ff9cfa886807ec0a8bdb838b09775d00c612a482R13) [[2]](diffhunk://#diff-f8ee6b133be44bdc6cb0d7b6ff9cfa886807ec0a8bdb838b09775d00c612a482R35) [[3]](diffhunk://#diff-f8ee6b133be44bdc6cb0d7b6ff9cfa886807ec0a8bdb838b09775d00c612a482R135) [[4]](diffhunk://#diff-f8ee6b133be44bdc6cb0d7b6ff9cfa886807ec0a8bdb838b09775d00c612a482L155-R159)

### Adjustments to default values:

* [`echoflow/include/echoflow/particle_filter_node.hpp`](diffhunk://#diff-c4dfeac197337364eaa97fbd31748e14ad2361b40cb8f503175351fae34e4f13L48-R50): Modified default values for `observation_sigma` (from 100.0 to 25.0) and `decay_factor` (from 0.95 to 0.5). Introduced a default value for `seed_fraction` (0.001).