### PR TITLE
Rename frame id parameter names for consistency

### DIFF
--- a/echoflow/config/particle_filter.yaml
+++ b/echoflow/config/particle_filter.yaml
@@ -12,7 +12,7 @@
       noise_std_yaw_rate: 1.0
       noise_std_speed: 4.0
     particle_filter_statistics:
-      frameId: map
+      frame_id: map
       length: 1500.0
       width: 1500.0
       resolution: 1.0

--- a/echoflow/config/radar_grid_map.yaml
+++ b/echoflow/config/radar_grid_map.yaml
@@ -3,7 +3,7 @@
     filter:
       near_clutter_range: 0.0
     map:
-      frameId: map
+      frame_id: map
       length: 1500.0              # meters
       width: 1500.0               # meters
       resolution: 1.0

--- a/echoflow/include/echoflow/particle_filter_node.hpp
+++ b/echoflow/include/echoflow/particle_filter_node.hpp
@@ -55,7 +55,7 @@ public:
     } particle_filter;
 
     struct {
-      std::string frameId = "map";
+      std::string frame_id = "map";
       double length = 1500.0;
       double width = 1500.0;
       double resolution = 50.0;

--- a/echoflow/package.xml
+++ b/echoflow/package.xml
@@ -10,9 +10,10 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <depend>eigen</depend>
   <depend>grid_map_core</depend>
+  <depend>grid_map_costmap_2d</depend>
   <depend>grid_map_cv</depend>
-  <depend>grid_map_ros</depend>
   <depend>grid_map_msgs</depend>
+  <depend>grid_map_ros</depend>
   <depend>marine_sensor_msgs</depend>
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>

--- a/echoflow/src/particle_filter_node.cpp
+++ b/echoflow/src/particle_filter_node.cpp
@@ -16,7 +16,7 @@ void ParticleFilterNode::Parameters::declare(rclcpp::Node * node)
   node->declare_parameter("particle_filter.noise_std_yaw_rate", particle_filter.noise_std_yaw_rate);
   node->declare_parameter("particle_filter.noise_std_speed", particle_filter.noise_std_speed);
 
-  node->declare_parameter("particle_filter_statistics.frameId", particle_filter_statistics.frameId);
+  node->declare_parameter("particle_filter_statistics.frame_id", particle_filter_statistics.frame_id);
   node->declare_parameter("particle_filter_statistics.length", particle_filter_statistics.length);
   node->declare_parameter("particle_filter_statistics.width", particle_filter_statistics.width);
   node->declare_parameter("particle_filter_statistics.resolution", particle_filter_statistics.resolution);
@@ -37,7 +37,7 @@ void ParticleFilterNode::Parameters::update(rclcpp::Node * node)
   node->get_parameter("particle_filter.noise_std_yaw_rate", particle_filter.noise_std_yaw_rate);
   node->get_parameter("particle_filter.noise_std_speed", particle_filter.noise_std_speed);
 
-  node->get_parameter("particle_filter_statistics.frameId", particle_filter_statistics.frameId);
+  node->get_parameter("particle_filter_statistics.frame_id", particle_filter_statistics.frame_id);
   node->get_parameter("particle_filter_statistics.length", particle_filter_statistics.length);
   node->get_parameter("particle_filter_statistics.width", particle_filter_statistics.width);
   node->get_parameter("particle_filter_statistics.resolution", particle_filter_statistics.resolution);
@@ -123,7 +123,7 @@ ParticleFilterNode::ParticleFilterNode()
   pf_statistics_->setGeometry(grid_map::Length(parameters_.particle_filter_statistics.length,
                                                parameters_.particle_filter_statistics.width),
                               parameters_.particle_filter_statistics.resolution);
-  pf_statistics_->setFrameId(parameters_.particle_filter_statistics.frameId);
+  pf_statistics_->setFrameId(parameters_.particle_filter_statistics.frame_id);
 
   last_update_time_ = now();
 }

--- a/echoflow/src/radar_grid_map_node.cpp
+++ b/echoflow/src/radar_grid_map_node.cpp
@@ -4,7 +4,7 @@ NS_HEAD
 
 void RadarGridMapNode::Parameters::declare(rclcpp::Node * node)
 {
-  node->declare_parameter("map.frameId", map.frame_id);
+  node->declare_parameter("map.frame_id", map.frame_id);
   node->declare_parameter("map.length", map.length);
   node->declare_parameter("map.width", map.width);
   node->declare_parameter("map.resolution", map.resolution);
@@ -15,7 +15,7 @@ void RadarGridMapNode::Parameters::declare(rclcpp::Node * node)
 
 void RadarGridMapNode::Parameters::update(rclcpp::Node * node)
 {
-  node->get_parameter("map.frameId", map.frame_id);
+  node->get_parameter("map.frame_id", map.frame_id);
   node->get_parameter("map.length", map.length);
   node->get_parameter("map.width", map.width);
   node->get_parameter("map.resolution", map.resolution);


### PR DESCRIPTION
Make parameter name for frame_id consistent across radar_grid_map, particle_filter, and particle filter statistics.