### PR TITLE
Make particle filter statistics cells NaN when no particles exist in that cell

### DIFF
--- a/echoflow/config/echoflow.rviz
+++ b/echoflow/config/echoflow.rviz
@@ -9,6 +9,7 @@ Panels:
         - /TF1/Tree1
         - "/Radar Returns: PointCloud21/Autocompute Value Bounds1"
         - /Radar Occupancy Map1/Position1
+        - /PointCloud21
       Splitter Ratio: 0.6028168797492981
     Tree Height: 700
   - Class: rviz_common/Selection
@@ -28,7 +29,7 @@ Panels:
     Experimental: false
     Name: Time
     SyncMode: 0
-    SyncSource: "Particle Cloud: PointCloud2"
+    SyncSource: PointCloud2
 Visualization Manager:
   Class: ""
   Displays:
@@ -267,6 +268,40 @@ Visualization Manager:
         Reliability Policy: Reliable
         Value: /aura/perception/sensors/halo_a/cell_heading_field
       Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: false
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: x
+      Class: rviz_default_plugins/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: Intensity
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 6.400000095367432
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: PointCloud2
+      Position Transformer: XYZ
+      Selectable: true
+      Size (Pixels): 4
+      Size (m): 0.10000000149011612
+      Style: Points
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /particles_per_cell
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
@@ -322,7 +357,7 @@ Visualization Manager:
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Scale: 0.3148864805698395
+      Scale: -0.2642516791820526
       Target Frame: aura/radar
       Value: TopDownOrtho (rviz_default_plugins)
       X: -170.27195739746094

--- a/echoflow/config/grid_map_visualization.yaml
+++ b/echoflow/config/grid_map_visualization.yaml
@@ -2,10 +2,10 @@ grid_map_visualization:
   ros__parameters:
     grid_map_topic: /aura/perception/sensors/halo_a/particle_filter_statistics
 
-    grid_map_visualizations: [occupancy_grid]
+    grid_map_visualizations: [particles_per_cell]
 
-    occupancy_grid:
-        type: occupancy_grid
+    particles_per_cell:
+        type: point_cloud
         params:
           layer: particles_per_cell
           data_min: 0.0

--- a/echoflow/launch/echoflow.launch.xml
+++ b/echoflow/launch/echoflow.launch.xml
@@ -9,14 +9,21 @@
     <push-ros-namespace namespace="$(var radar1_ns)"/>
 
     <!-- Launch radar to pointcloud node -->
-    <include file="$(find-pkg-share marine_radar_tracker)/launch/marine_radar_to_pointcloud.launch.xml" />
+    <!--<include file="$(find-pkg-share marine_radar_tracker)/launch/marine_radar_to_pointcloud.launch.xml" />-->
 
     <!-- Launch particle filter and radar grid map node -->
-    <node pkg="echoflow" exec="particle_filter_node" name="particle_filter_node">
+    <node pkg="echoflow" exec="particle_filter">
       <param from="$(find-pkg-share echoflow)/config/particle_filter.yaml" />
       <!--<param from="$(find-pkg-share echoflow)/config/radar_grid_map.yaml" />-->
     </node>
+
   </group>
+
+    <node pkg="grid_map_visualization" exec="grid_map_visualization" name="grid_map_visualization" output="screen">
+      <param from="$(find-pkg-share echoflow)/config/grid_map_visualization.yaml" />
+    </node>
+
+
 
   <group>
     <push-ros-namespace namespace="$(var radar2_ns)"/>
@@ -24,7 +31,7 @@
   </group>
 
   <!-- Launch Rviz2 with configuration file -->
-  <node pkg="rviz2" exec="rviz2" name="rviz2" output="screen"
-        args="-d $(find-pkg-share echoflow)/config/echoflow.rviz" />
+  <!--<node pkg="rviz2" exec="rviz2" name="rviz2" output="screen"
+        args="-d $(find-pkg-share echoflow)/config/echoflow.rviz" />-->
 
 </launch>

--- a/echoflow/src/particle_filter_node.cpp
+++ b/echoflow/src/particle_filter_node.cpp
@@ -351,15 +351,19 @@ void ParticleFilterNode::publishCellHeadingField()
   geometry_msgs::msg::Pose pose;
   geometry_msgs::msg::Quaternion quaternion;
   for (grid_map::GridMapIterator iterator(*pf_statistics_); !iterator.isPastEnd(); ++iterator) {
-    pose.position.x = pf_statistics_->at("x_position_mean", *iterator);
-    pose.position.y = pf_statistics_->at("y_position_mean", *iterator);
-    pose.position.z = 0.0f;
-    quaternion = headingToQuaternion(pf_statistics_->at("heading_mean", *iterator));
-    pose.orientation.x = quaternion.x;
-    pose.orientation.y = quaternion.y;
-    pose.orientation.z = quaternion.z;
-    pose.orientation.w = quaternion.w;
-    heading_field.poses.push_back(pose);
+    if (std::isnan(pf_statistics_->at("particles_per_cell", *iterator))) {
+      continue;
+    } else {
+      pose.position.x = pf_statistics_->at("x_position_mean", *iterator);
+      pose.position.y = pf_statistics_->at("y_position_mean", *iterator);
+      pose.position.z = 0.0f;
+      quaternion = headingToQuaternion(pf_statistics_->at("heading_mean", *iterator));
+      pose.orientation.x = quaternion.x;
+      pose.orientation.y = quaternion.y;
+      pose.orientation.z = quaternion.z;
+      pose.orientation.w = quaternion.w;
+      heading_field.poses.push_back(pose);
+    }
   }
 
   cell_heading_field_pub_->publish(heading_field);


### PR DESCRIPTION
Fix particle filter statistics grid_map to make empty cells NaN instead of zero. 

Also fixes #8 

![pf_nan_fix](https://github.com/user-attachments/assets/ed347dc6-1842-426c-92d6-d9ec9441bf4c)
